### PR TITLE
Fix a reference

### DIFF
--- a/index.qmd
+++ b/index.qmd
@@ -116,7 +116,7 @@ informs the planned curriculum for research software engineering.
 
 Similar efforts were carried out in allied communities and have yielded tailored curricula,
 such as the RSE-HPC curriculum [@Filinger2025] by the UNIVERSE-HPC project,
-the RSE curriculum for computational scientists and engineers [@Chourdakis2025] at the Technical University of Munich,
+the RSE curriculum track for computational scientists and engineers [@Chourdakis2025] at the Technical University of Munich,
 the Simulation Software Engineering course [@Uekermann2021] at the University of Stuttgart,
 or the Bachelor's and Master's program "Simulation Technology" from the Cluster
 of Excellence "Data-Integrated Simulation Science (SimTech)" [@SimTech2019]

--- a/index.qmd
+++ b/index.qmd
@@ -116,7 +116,7 @@ informs the planned curriculum for research software engineering.
 
 Similar efforts were carried out in allied communities and have yielded tailored curricula,
 such as the RSE-HPC curriculum [@Filinger2025] by the UNIVERSE-HPC project,
-the RSE curriculum for computer scientists [@Chourdakis2025] at the Technical University of Munich,
+the RSE curriculum for computational scientists and engineers [@Chourdakis2025] at the Technical University of Munich,
 the Simulation Software Engineering course [@Uekermann2021] at the University of Stuttgart,
 or the Bachelor's and Master's program "Simulation Technology" from the Cluster
 of Excellence "Data-Integrated Simulation Science (SimTech)" [@SimTech2019]


### PR DESCRIPTION
I had a quick read through the paper and noticed the reference to https://eceasst.org/index.php/eceasst/article/view/2615 (nice!).

This PR fixes a small issue on how this is referred to: it is not for computer scientists, but for a much more diverse group (computational scientists and various engineers). It is also not a full curriculum, but just a track of one.

(the paper looks good, thank you for writing it! Please don't even consider any authorship for me, I have not contributed, and I don't have the capacity for any new projects at the moment.)